### PR TITLE
Handle list items without either <term> or <description>

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Transform/TripleSlashCommentTransform.xsl
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Transform/TripleSlashCommentTransform.xsl
@@ -195,8 +195,15 @@
             <ul>
               <xsl:for-each select="item">
                 <li>
-                  <xsl:apply-templates select="term" />
-                  <xsl:apply-templates select="description" />
+                  <xsl:choose>
+                    <xsl:when test="self::node()[description|term]">
+                      <xsl:apply-templates select="term" />
+                      <xsl:apply-templates select="description" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:apply-templates />
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </li>
               </xsl:for-each>
             </ul>
@@ -205,8 +212,15 @@
             <ol>
               <xsl:for-each select="item">
                 <li>
-                  <xsl:apply-templates select="term" />
-                  <xsl:apply-templates select="description" />
+                  <xsl:choose>
+                    <xsl:when test="self::node()[description|term]">
+                      <xsl:apply-templates select="term" />
+                      <xsl:apply-templates select="description" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:apply-templates />
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </li>
               </xsl:for-each>
             </ol>

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
@@ -77,6 +77,9 @@ namespace Example
         <item>
             <description>item2 in bullet list</description>
         </item>
+        <item>
+            loose text <i>not</i> wrapped in description
+        </item>
     </list>
     </remarks>
     <returns>Task<see cref='T:System.AccessViolationException'/> returns</returns>
@@ -163,7 +166,9 @@ Classes in assemblies are by definition complete.
             word inside list->listItem->list->listItem->para.>
             the second line.
 </li><li>item2 in numbered list</li></ol>
-</li><li>item2 in bullet list</li></ul>
+</li><li>item2 in bullet list</li><li>
+loose text <em>not</em> wrapped in description
+</li></ul>
 ".Replace("\r\n", "\n"),
 remarks);
 


### PR DESCRIPTION
The items of "bullet" or "number" lists should be included even if they do not have either "term" or "description", for parity with SandCastle and IntelliSense.